### PR TITLE
Fix play/pause button being shoved offscreen by long titles

### DIFF
--- a/src/player/features/playlists/PlaylistItem.tsx
+++ b/src/player/features/playlists/PlaylistItem.tsx
@@ -88,14 +88,14 @@ export function PlaylistItem({
           padding: 2,
           display: "flex",
           justifyContent: "space-between",
-          alignItems: "center",
+          alignItems: "flex-end",
           position: "absolute",
           bottom: 0,
           width: "100%",
           pointerEvents: "none",
         }}
       >
-        <Typography variant="h5" component="div">
+        <Typography variant="h6" component="div" sx={{overflow: "hidden", paddingBottom: "8px"}}>
           {playlist.title}
         </Typography>
         <IconButton

--- a/src/player/features/soundboards/SoundboardItem.tsx
+++ b/src/player/features/soundboards/SoundboardItem.tsx
@@ -67,14 +67,14 @@ export function SoundboardItem({
           padding: 2,
           display: "flex",
           justifyContent: "space-between",
-          alignItems: "center",
+          alignItems: "flex-end",
           position: "absolute",
           bottom: 0,
           width: "100%",
           pointerEvents: "none",
         }}
       >
-        <Typography variant="h5" component="div">
+        <Typography variant="h6" component="div" sx={{overflow: "hidden", paddingBottom: "8px"}}>
           {soundboard.title}
         </Typography>
         <IconButton


### PR DESCRIPTION
Fixes #56. As a bonus, also anchors the play button to the bottom.

The padding feels a bit hacky but I don't really know what alternative there is, suggestions appreciated if available.

![image](https://user-images.githubusercontent.com/1286721/208289519-f4d735e3-07e8-42f1-a26e-1de80a591784.png)


